### PR TITLE
dev-python/distribute license change

### DIFF
--- a/dev-python/distribute/distribute-0.7.3.ebuild
+++ b/dev-python/distribute/distribute-0.7.3.ebuild
@@ -7,7 +7,7 @@ DESCRIPTION="distribute legacy wrapper"
 HOMEPAGE="http://packages.python.org/distribute"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.zip"
 
-LICENSE="PSF ZPL"
+LICENSE="|| (PSF ZPL)"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~arm"
 


### PR DESCRIPTION
actually is licensed as PFL or ZPL, this solve the issue that the PFL license (without version) is not in the gentoo main repository