### PR TITLE
Fix ROS path to include the EPREFIX

### DIFF
--- a/eclass/ament-cmake.eclass
+++ b/eclass/ament-cmake.eclass
@@ -99,9 +99,16 @@ ament-cmake_src_configure_internal() {
 		append-cxxflags '-std=c++11'
 	fi
 	if [ -n "${AMENT_DO_PYTHON_MULTIBUILD}" ] ; then
+		# Figure out if the system uses lib64 or lib folder
+		local sitedir="$(python_get_sitedir)";
+		if [[ $sitedir = *"lib64"* ]]; then
+		    local lib_str="lib64"
+		else
+			local lib_str="lib"
+		fi
 		local mycmakeargs=(
 			-DPYTHON_EXECUTABLE="${PYTHON}"
-			"-DPYTHON_INSTALL_DIR=${EPREFIX%/}/${ROS_PREFIX%/}/lib64/${EPYTHON}/site-packages"
+			"-DPYTHON_INSTALL_DIR=${lib_str}/${EPYTHON}/site-packages"
 			"${mycmakeargs[@]}"
 		)
 		python_export PYTHON_SCRIPTDIR

--- a/eclass/ament-cmake.eclass
+++ b/eclass/ament-cmake.eclass
@@ -91,21 +91,17 @@ ament-cmake_src_prepare() {
 # @DESCRIPTION:
 # Internal decoration of cmake-utils_src_configure to handle multiple python installs.
 ament-cmake_src_configure_internal() {
-	export PYTHONPATH="/${ROS_PREFIX}/lib64/${EPYTHON}/site-packages"
-	if [ -f /${ROS_PREFIX}/setup.bash ]; then
-		source /${ROS_PREFIX}/setup.bash
+	export PYTHONPATH="${EPREFIX%/}/${ROS_PREFIX%/}/lib64/${EPYTHON}/site-packages"
+	if [ -f ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash ]; then
+		source ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash
 	fi
 	if [[ -z $CPP11 ]]; then
 		append-cxxflags '-std=c++11'
 	fi
 	if [ -n "${AMENT_DO_PYTHON_MULTIBUILD}" ] ; then
-		local sitedir="$(python_get_sitedir)"
-		local sitedir="${sitedir/\/usr\//}"
-		local sitedir="${sitedir/lib64/lib}"
-		local sitedir="${sitedir/lib/lib64}"
 		local mycmakeargs=(
 			-DPYTHON_EXECUTABLE="${PYTHON}"
-			"-DPYTHON_INSTALL_DIR=${sitedir}"
+			"-DPYTHON_INSTALL_DIR=${EPREFIX%/}/${ROS_PREFIX%/}/lib64/${EPYTHON}/site-packages"
 			"${mycmakeargs[@]}"
 		)
 		python_export PYTHON_SCRIPTDIR
@@ -135,15 +131,15 @@ ament-cmake_src_configure() {
 
 	export AMENT_PREFIX_PATH="${EPREFIX%/}/${ROS_PREFIX}"
 	export ROS_ROOT="${EPREFIX%/}/${ROS_PREFIX}"
-	export DEST_SETUP_DIR="/${ROS_PREFIX}"
+	export DEST_SETUP_DIR="${EPREFIX%/}/${ROS_PREFIX}"
 	if [ -z $BUILD_BINARY ]; then
 		export BUILD_BINARY="1"
 	fi
 	local mycmakeargs=(
 		-DAMENT_ENABLE_TESTING="$(usex test 1 0)"
 		-DAMENT_BUILD_BINARY_PACKAGE=${BUILD_BINARY}
-		-DCMAKE_PREFIX_PATH=${SYSROOT:-${EROOT%/}}/${ROS_PREFIX}
-		-DCMAKE_INSTALL_PREFIX=${EROOT%/}/${ROS_PREFIX}
+		-DCMAKE_PREFIX_PATH=${SYSROOT:-${EPREFIX%/}}/${ROS_PREFIX}
+		-DCMAKE_INSTALL_PREFIX=${EPREFIX%/}/${ROS_PREFIX}
 		${mycmakeargs[@]}
 	)
 	cmake-utils_src_configure
@@ -158,8 +154,8 @@ ament-cmake_src_configure() {
 # @DESCRIPTION:
 # Builds a catkin-based package.
 ament-cmake_src_compile() {
-	if [ -f /${ROS_PREFIX}/setup.bash ]; then
-		source /${ROS_PREFIX}/setup.bash
+	if [ -f ${EPREFIX%/}/${ROS_PREFIX}/setup.bash ]; then
+		source ${EPREFIX%/}/${ROS_PREFIX}/setup.bash
 	fi
 
 	rm -f ${WORKDIR}/${P}/README* # prevents conflicts
@@ -207,7 +203,7 @@ ros-catkin_src_test() {
 # @DESCRIPTION:
 # Decorator around cmake-utils_src_install to ensure python scripts are properly handled w.r.t. python-exec2.
 ament-cmake_src_install_with_python() {
-	python_scriptinto /${ROS_PREFIX}/bin
+	python_scriptinto ${EPREFIX%/}/${ROS_PREFIX}/bin
 	python_export PYTHON_SCRIPTDIR
 	if [ -n "${AMENT_IN_SOURCE_BUILD}" ] ; then
 		export CMAKE_USE_DIR="${BUILD_DIR}"

--- a/eclass/ament-python.eclass
+++ b/eclass/ament-python.eclass
@@ -18,7 +18,7 @@ ament-python_src_unpack() {
 }
 
 ament-python_python_install() {
-	distutils-r1_python_install --prefix="/${ROS_PREFIX}"
+	distutils-r1_python_install --prefix="${EPREFIX%/}/${ROS_PREFIX%/}"
 }
 
 EXPORT_FUNCTIONS src_unpack python_install

--- a/eclass/ros-cmake.eclass
+++ b/eclass/ros-cmake.eclass
@@ -148,20 +148,16 @@ ros-cmake_src_prepare() {
 # @DESCRIPTION:
 # Internal decoration of cmake-utils_src_configure to handle multiple python installs.
 ros-cmake_src_configure_internal() {
-	if [ -f /${ROS_PREFIX}/setup.bash ]; then
-		source /${ROS_PREFIX}/setup.bash
+	if [ -f ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash ]; then
+		source ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash
 	fi
 	if [[ -z $CPP11 ]]; then
 		append-cxxflags '-std=c++11'
 	fi
 	if [ -n "${CATKIN_DO_PYTHON_MULTIBUILD}" ] ; then
-		local sitedir="$(python_get_sitedir)"
-		local sitedir="${sitedir/\/usr\//}"
-		local sitedir="${sitedir/lib64/lib}"
-		local sitedir="${sitedir/lib/lib64}"
 		local mycmakeargs=(
 			-DPYTHON_EXECUTABLE="${PYTHON}"
-			"-DPYTHON_INSTALL_DIR=${sitedir}"
+			"-DPYTHON_INSTALL_DIR=${EPREFIX%/}/${ROS_PREFIX%/}/lib/${EPYTHON%/}/site-packages"
 			"${mycmakeargs[@]}"
 		)
 		python_export PYTHON_SCRIPTDIR
@@ -182,8 +178,8 @@ ros-cmake_src_configure_internal() {
 # @DESCRIPTION:
 # Configures a catkin-based package.
 ros-cmake_src_configure() {
-	if [ -f /${ROS_PREFIX}/setup.bash ]; then
-		source /${ROS_PREFIX}/setup.bash
+	if [ -f ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash ]; then
+		source ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash
 	fi
 	if [[ -z $CPP11 ]]; then
 		append-cxxflags '-std=c++11'
@@ -200,15 +196,15 @@ ros-cmake_src_configure() {
 		use ros_messages_nodejs || ROS_LANG_DISABLE="${ROS_LANG_DISABLE}:gennodejs"
 		export ROS_LANG_DISABLE
 	fi
-	export DEST_SETUP_DIR="/${ROS_PREFIX}"
+	export DEST_SETUP_DIR="${EPREFIX%/}/${ROS_PREFIX%/}"
 	if [ -z $BUILD_BINARY ]; then
 		export BUILD_BINARY="1"
 	fi
 	local mycmakeargs=(
 		-DCATKIN_ENABLE_TESTING="$(usex test 1 0)"
 		-DCATKIN_BUILD_BINARY_PACKAGE=${BUILD_BINARY}
-		-DCMAKE_PREFIX_PATH=${SYSROOT:-${EROOT%/}}/${ROS_PREFIX}
-		-DCMAKE_INSTALL_PREFIX=${EROOT%/}/${ROS_PREFIX}
+		-DCMAKE_PREFIX_PATH=${SYSROOT:-${EPREFIX%/}}/${ROS_PREFIX}
+		-DCMAKE_INSTALL_PREFIX=${EPREFIX%/}/${ROS_PREFIX}
 		${mycmakeargs[@]}
 	)
 	cmake-utils_src_configure
@@ -223,8 +219,8 @@ ros-cmake_src_configure() {
 # @DESCRIPTION:
 # Builds a catkin-based package.
 ros-cmake_src_compile() {
-	if [ -f /${ROS_PREFIX}/setup.bash ]; then
-		source /${ROS_PREFIX}/setup.bash
+	if [ -f ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash ]; then
+		source ${EPREFIX%/}/${ROS_PREFIX%/}/setup.bash
 	fi
 
 	rm -f ${WORKDIR}/${P}/README* # prevents conflicts
@@ -272,7 +268,7 @@ ros-catkin_src_test() {
 # @DESCRIPTION:
 # Decorator around cmake-utils_src_install to ensure python scripts are properly handled w.r.t. python-exec2.
 ros-cmake_src_install_with_python() {
-	python_scriptinto /${ROS_PREFIX}/bin
+	python_scriptinto ${EPREFIX%/}/${ROS_PREFIX%/}/bin
 	python_export PYTHON_SCRIPTDIR
 	if [ -n "${CATKIN_IN_SOURCE_BUILD}" ] ; then
 		export CMAKE_USE_DIR="${BUILD_DIR}"

--- a/eclass/ros-cmake.eclass
+++ b/eclass/ros-cmake.eclass
@@ -155,9 +155,17 @@ ros-cmake_src_configure_internal() {
 		append-cxxflags '-std=c++11'
 	fi
 	if [ -n "${CATKIN_DO_PYTHON_MULTIBUILD}" ] ; then
+		# Figure out if the system uses lib64 or lib folder
+		local sitedir="$(python_get_sitedir)";
+		if [[ $sitedir = *"lib64"* ]]; then
+		    local lib_str="lib64"
+		else
+			local lib_str="lib"
+		fi
+
 		local mycmakeargs=(
 			-DPYTHON_EXECUTABLE="${PYTHON}"
-			"-DPYTHON_INSTALL_DIR=${EPREFIX%/}/${ROS_PREFIX%/}/lib/${EPYTHON%/}/site-packages"
+			"-DPYTHON_INSTALL_DIR=${lib_str}/${EPYTHON%/}/site-packages"
 			"${mycmakeargs[@]}"
 		)
 		python_export PYTHON_SCRIPTDIR


### PR DESCRIPTION
So in environments like Gentoo Prefix paths are correct.

Running a recompilation right now, don't merge yet.