### PR TITLE
Fix install dir to support Gentoo Prefix, crosscompiling and normal

### DIFF
--- a/eclass/ros-cmake.eclass
+++ b/eclass/ros-cmake.eclass
@@ -211,7 +211,7 @@ ros-cmake_src_configure() {
 	local mycmakeargs=(
 		-DCATKIN_ENABLE_TESTING="$(usex test 1 0)"
 		-DCATKIN_BUILD_BINARY_PACKAGE=${BUILD_BINARY}
-		-DCMAKE_PREFIX_PATH=${SYSROOT:-${EPREFIX%/}}/${ROS_PREFIX}
+		-DCMAKE_PREFIX_PATH=${EPREFIX:-${SYSROOT%/}}/${ROS_PREFIX}
 		-DCMAKE_INSTALL_PREFIX=${EPREFIX%/}/${ROS_PREFIX}
 		${mycmakeargs[@]}
 	)


### PR DESCRIPTION
We had the logic inverted here (to the best of my knowledge).

This is the same error I reported upstream in `log4cxx`: https://bugs.gentoo.org/654678

```bash
-DCMAKE_PREFIX_PATH=${EPREFIX:-${SYSROOT%/}}/${ROS_PREFIX}
```
What is happening here is that (with the operator `:-` ).
* If the variable EPREFIX is set, that one is used. (So we are in Gentoo Prefix). Resulting path `/myprefix/gentoo/opt/ros/rosversion`.
* If the variable is not set we use instead SYSROOT. Which by what I could find, is set when crosscompiling Gentoo (without prefix), that would result in path `/mysysroot/opt/ros/rosversion`. If it's not set, that would become empty and the resulting path would be `/opt/ros/rosversion`.

It did the trick to keep compiling on Gentoo Prefix, and I think it will keep any other setup working too.
